### PR TITLE
Allow non root users to start services fix #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ Search for the keywords to learn more about each warning.
 To ignore, add // eslint-disable-next-line to the line before.
 ```
 
-* In directory [[Requestrr.WebApi](Requestrr.WebApi) run `dotnet publish -c release -o publish -r linux-x64`.
+* In directory [Requestrr.WebApi](Requestrr.WebApi) run `dotnet publish -c release -o publish -r linux-x64`.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,34 @@ Then use the following command create and start the container:
       --restart=unless-stopped \
       darkalfx/requestrr
 
+You can also choose to run the container as a different user. See [docker run](https://docs.docker.com/engine/reference/run/#user) reference for how to set the user for your container.
+
 Then simply access the web portal at http://youraddress:4545/ to create your admin account, then you can configure everything through the web portal.
 
 Once you have configured the bot and invited it to your Discord server, simply type **!help** to see all available commands.
+
+Build Instructions
+==================
+
+### Setup
+* npm. You can install npm via brew on mac. On mac you might need to re install your xcode command line tools. See https://medium.com/flawless-app-stories/gyp-no-xcode-or-clt-version-detected-macos-catalina-anansewaa-38b536389e8d.
+* .netcore sdk. Download [SDK 3.1.201](https://dotnet.microsoft.com/download/dotnet-core/3.1) installer for your environment.
+
+### Building
+* In directory [Requestrr.WebApi/ClientApp](Requestrr.WebApi/ClientApp) run `npm run install:clean`. You can safefly exit it once the build is done running. For example
+```
+./src/components/Inputs/MultiDropdown.jsx
+  Line 29:  Expected '!==' and instead saw '!='  eqeqeq
+  Line 53:  No duplicate props allowed           react/jsx-no-duplicate-props
+
+./src/views/TvShows.jsx
+  Line 38:  'Input' is defined but never used  no-unused-vars
+
+./src/views/Movies.jsx
+  Line 38:  'Input' is defined but never used  no-unused-vars
+
+Search for the keywords to learn more about each warning.
+To ignore, add // eslint-disable-next-line to the line before.
+```
+
+* In directory [[Requestrr.WebApi](Requestrr.WebApi) run `dotnet publish -c release -o publish -r linux-x64`.

--- a/Requestrr.WebApi/dockerfile
+++ b/Requestrr.WebApi/dockerfile
@@ -1,6 +1,10 @@
 FROM microsoft/dotnet:3.0-sdk
 
 COPY publish/ /root/
+
+# allow all users access to this so we can run container as non root.
+RUN chmod -R 755 /root
+
 WORKDIR /root/
 
 ENV ASPNETCORE_URLS="http://*:4545"


### PR DESCRIPTION
This fixes non root users being able to start the service. I have confirmed that i can now pass the --user flag to docker run and be able to start the container.

Adding support for PGID and PUID seem a lot more work. See https://www.reddit.com/r/docker/comments/9iwe3t/where_can_i_find_out_how_puid_and_pgid_are_used/ May be long term having linuxserver add support for the docker image would be ideal?

https://docs.linuxserver.io/general/understanding-puid-and-pgid