### PR TITLE
Updated discordlink to new API domain

### DIFF
--- a/Requestrr.WebApi/ClientApp/src/views/ChatClients.jsx
+++ b/Requestrr.WebApi/ClientApp/src/views/ChatClients.jsx
@@ -617,7 +617,7 @@ class ChatClients extends React.Component {
                       <Row>
                         <Col>
                           <FormGroup className="text-right">
-                            <Input id="discordlink" readOnly={true} className="d-none" value={"https://discordapp.com/oauth2/authorize?&client_id=" + this.state.clientId + "&scope=bot&permissions=522304"} />
+                            <Input id="discordlink" readOnly={true} className="d-none" value={"https://discord.com/api/oauth2/authorize?&client_id=" + this.state.clientId + "&scope=bot&permissions=522304"} />
                             <button onClick={this.onTestSettings} disabled={!(this.validateBotToken() && this.validateClientId())} className="btn mt-3 btn-icon btn-3 btn-default" type="button">
                               <span className="btn-inner--icon">
                                 {


### PR DESCRIPTION
Discord recently announced the migration of their API from discordapp.com to discord.com

discordapp.com will cease handling API requests as of November 7, 2020. 

This change updates discordurl to the new address as per the official documentation at https://discord.com/developers/docs/topics/oauth2