### PR TITLE
Do not redirect static assets

### DIFF
--- a/Requestrr.WebApi/ClientApp/public/index.html
+++ b/Requestrr.WebApi/ClientApp/public/index.html
@@ -22,7 +22,7 @@
 
 <head>
   <script>
-    if (!window.location.pathname.toLowerCase().includes("/auth") && !window.location.pathname.toLowerCase().includes("/admin")) {
+    if (!window.location.pathname.toLowerCase().includes("/auth") && !window.location.pathname.toLowerCase().includes("/admin") && !window.location.pathname.toLowerCase().includes("/static")) {
       var newHref = window.location.href + "/auth/login"; 
       newHref = newHref.replace(/\/\//g, "/"),
       newHref = newHref.replace("http:/", "http://");


### PR DESCRIPTION
This fixes a regression in 169a9fc (V1.0.14) where static asset requests were incorrectly redirected to the login URI.

Fixes #81.