### PR TITLE
fix: update .net link and create tmp dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Build Instructions
 
 ### Setup
 * npm. You can install npm via brew on mac. On mac you might need to re install your xcode command line tools. See https://medium.com/flawless-app-stories/gyp-no-xcode-or-clt-version-detected-macos-catalina-anansewaa-38b536389e8d.
-* .netcore sdk. Download [SDK 3.1.201](https://dotnet.microsoft.com/download/dotnet-core/3.1) installer for your environment.
+* .netcore sdk. Download [SDK 5.0.402](https://dotnet.microsoft.com/download/dotnet-core/5.0) installer for your environment.
 
 ### Building
 * In directory [Requestrr.WebApi/ClientApp](Requestrr.WebApi/ClientApp) run `npm run install:clean`. You can safefly exit it once the build is done running. For example

--- a/Requestrr.WebApi/dockerfile
+++ b/Requestrr.WebApi/dockerfile
@@ -3,7 +3,8 @@ FROM mcr.microsoft.com/dotnet/aspnet:5.0
 COPY publish/ /root/
 
 # allow all users access to this so we can run container as non root.
-RUN chmod -R 755 /root
+# create /root/tmp if nonexistent
+RUN chmod -R 755 /root && mkdir /root/tmp
 
 WORKDIR /root/
 


### PR DESCRIPTION
fix(docs): point .net link in README to link to .net 5.0 rather than 3.1
fix(docker): mkdir /root/tmp to avoid ENOENT error

the `tmp` folder is not created automatically, which led to a `Sequence contains no elements` error when building from source. this addition to the dockerfile fixes it.

The .net link in `README.md` was directed at .net 3.1 while `CONTRIBUTING` and `dockerfile` targeted 5.0 